### PR TITLE
Add coverage folder to gitignore for simplecov.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /yarn-error.log
 
 .byebug_history
+
+# Ignore simplecov coverage
+/coverage


### PR DESCRIPTION
* Add 'coverage' to .gitignore so coverage file will be ignored for pushes to github.